### PR TITLE
DEV: Fix PostsController params deprecation

### DIFF
--- a/assets/javascripts/discourse/components/docked-composer.js.es6
+++ b/assets/javascripts/discourse/components/docked-composer.js.es6
@@ -19,7 +19,7 @@ const _create_serializer = {
         raw: 'reply',
         title: 'title',
         topic_id: 'topic.id',
-        target_usernames: 'targetUsernames',
+        target_recipients: 'targetUsernames',
       };
 
 const START_EVENTS = "touchstart mousedown";


### PR DESCRIPTION
`target_usernames` was deprecated in favor of `target_recipients`